### PR TITLE
Bump versions

### DIFF
--- a/Difi.Felles.Utility.Resources/Difi.Felles.Utility.Resources.csproj
+++ b/Difi.Felles.Utility.Resources/Difi.Felles.Utility.Resources.csproj
@@ -38,7 +38,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Digipost.Api.Client.Shared" Version="7.0.0" />
+      <PackageReference Include="Digipost.Api.Client.Shared" Version="7.0.1" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(Configuration)' == 'Debug'">

--- a/Difi.Felles.Utility.Tester/Difi.Felles.Utility.Tester.csproj
+++ b/Difi.Felles.Utility.Tester/Difi.Felles.Utility.Tester.csproj
@@ -59,11 +59,11 @@
         </None>
     </ItemGroup>
     <ItemGroup>
-      <PackageReference Include="Digipost.Api.Client.Shared" Version="7.0.0" />
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+      <PackageReference Include="Digipost.Api.Client.Shared" Version="7.0.1" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
       <PackageReference Include="xunit.assert" Version="2.4.1" />
       <PackageReference Include="xunit.core" Version="2.4.1" />
-      <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+      <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     </ItemGroup>
     
 </Project>

--- a/Difi.Felles.Utility/Difi.Felles.Utility.csproj
+++ b/Difi.Felles.Utility/Difi.Felles.Utility.csproj
@@ -55,7 +55,7 @@
         </None>
     </ItemGroup>
     <ItemGroup>
-      <PackageReference Include="Digipost.Api.Client.Shared" Version="7.0.0" />
+      <PackageReference Include="Digipost.Api.Client.Shared" Version="7.0.1" />
       <PackageReference Include="System.Security.Cryptography.Xml" Version="4.7.0" />
     </ItemGroup>
     


### PR DESCRIPTION
Digipost.Api.Client.Shared to newest (7.0.1)
Bump test dependencies

Dette er et steg på vei for at https://github.com/difi/oppslagstjeneste-klient-dotnet , https://github.com/difi/felles-utility-dotnet og https://github.com/difi/oppslagstjeneste-klient-dotnet skal avhenge av samme versjon av delte avhengigheter